### PR TITLE
Typo in sender_address

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -24,7 +24,7 @@ open = 1
 # omit this is not applicable
 max_attendees = 150
 
-registration_notify_address  = orga-gpw2017@list.cluster-team.com
+registration_notify_address  = vorstand+gpw2017@frankfurt.pm
 registration_notify_language = de
 
 # optional
@@ -36,12 +36,12 @@ registration_notify_language = de
 gratis = 0
 
 [email]
-sender_address = orga-gpw2017@list.cluster-team.com
+sender_address = vortand+gpw2017@frankfurt.pm
 
 [talks]
 # conference dates
-start_date = 2017-03-08 18:00:00
-end_date   = 2017-03-12 17:00:00
+start_date = 2017-06-26 10:00:00
+end_date   = 2017-06-28 17:30:00
 
 # default talk durations
 durations = 10 20 40
@@ -63,7 +63,7 @@ edition_open  = 1
 show_schedule = 1
 
 # schedule date to show when none specified
-schedule_default = 2017-03-09
+schedule_default = 2017-06-26
 
 # show accepted talks, or all
 show_all  = 0
@@ -92,14 +92,12 @@ level4_name_en = Familar with subject
 
 [rooms]
 # list of rooms (must match /r\d+/)
-rooms = r1 r2
+rooms = r1
 
 # room names in all supported languages
-r1_name_de = DATEV
-r1_name_en = DATEV
+r1_name_de = Hamburg.pm
+r1_name_en = Hamburg.pm
 
-r2_name_de = Booking.com
-r2_name_en = Booking.com
 
 [payment]
 open        = 1
@@ -121,7 +119,7 @@ currency    = " EUR"
 # the products your are selling
 # these are non user visible product codes for configuration purposes only
 # "registration" is special - it's the registration product
-products    = registration dinner partner_sat partner_wed partner_thu partner_fri
+products    = registration dinner
 
 # Details on each product
 [product_registration]

--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -36,7 +36,7 @@ registration_notify_language = de
 gratis = 0
 
 [email]
-sender_address = vortand+gpw2017@frankfurt.pm
+sender_address = vorstand+gpw2017@frankfurt.pm
 
 [talks]
 # conference dates


### PR DESCRIPTION
The mail you get after registration has this header:
`From: vortand+gpw2017@frankfurt.pm`
It's missing an **s**, fixed in act.ini.
